### PR TITLE
[OPS-106] updated repo URL and key url in defaults.

### DIFF
--- a/elasticsearch/defaults.yaml
+++ b/elasticsearch/defaults.yaml
@@ -1,10 +1,10 @@
 {% load_yaml as rawmap_osfam %}
 Debian:
   repo:
-    url: http://packages.elasticsearch.org/elasticsearch/1.3/debian
+    url: https://packages.elastic.co/elasticsearch/2.x/debian
     dist: stable
     comps: main
-    keyurl: http://packages.elasticsearch.org/GPG-KEY-elasticsearch
+    keyurl: https://packages.elastic.co/GPG-KEY-elasticsearch
   pkgs:
     - elasticsearch
   service: {}


### PR DESCRIPTION
This ensures the repo URL and key url points to the 2.x repo and keys.

@timoguin 
